### PR TITLE
CONTRIB-3805 - More exact inclusion ported to 2.2 Stable.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -20,7 +20,7 @@
   along with this program.  If not, see http://www.gnu.org/licenses/.
  */
 
- require_once('config.php'); // For Collaped Topics defaults.
+require_once($CFG->dirroot . '/course/format/topcoll/config.php'); // For Collaped Topics defaults.
 
 /**
  * Indicates this format uses sections.


### PR DESCRIPTION
This back-ports a fix in 2.3 stable to the 2.2 stable 
