### PR TITLE
Fix broken default for defaulttoggleiconsize

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -291,7 +291,7 @@ if ($ADMIN->fulltree) {
     $name = 'format_topcoll/defaulttoggleiconsize';
     $title = get_string('defaulttoggleiconsize', 'format_topcoll');
     $description = get_string('defaulttoggleiconsize_desc', 'format_topcoll');
-    $default = 'medium';
+    $default = 'tc-medium';
     $choices = array(
         'tc-small' => new lang_string('small', 'format_topcoll'),
         'tc-medium' => new lang_string('medium', 'format_topcoll'),


### PR DESCRIPTION
This was causing the 'new admin settings' page to appear after installation (breaking a lot of behat tests on the site).