### PR TITLE
format_topcoll: Treat themes using Boost as a parent the same as Boost

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -79,6 +79,10 @@ class format_topcoll_renderer extends format_section_renderer_base {
 
         if (strcmp($page->theme->name, 'boost') === 0) {
             $this->bsnewgrid = true;
+        } else if (!empty($page->theme->parents)) {
+            if (in_array('boost', $page->theme->parents) === true) {
+                $this->bsnewgrid = true;
+            }
         }
     }
 


### PR DESCRIPTION
Currently the layout is broken if using a custom theme based on Boost (and using it as a parent).