### PR TITLE
Remove README link from course settings

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -792,13 +792,6 @@ class format_topcoll extends format_base {
                 $courseformatoptionsedit['togglebackgroundhoveopacity'] = array(
                     'label' => get_config('format_topcoll', 'defaulttgbghvropacity'), 'element_type' => 'hidden');
             }
-            $readme = new moodle_url('/course/format/topcoll/Readme.md');
-            $readme = html_writer::link($readme, 'Readme.md', array('target' => '_blank'));
-            $courseformatoptionsedit['readme'] = array(
-                    'label' => get_string('readme_title', 'format_topcoll'),
-                    'element_type' => 'static',
-                    'element_attributes' => array(get_string('readme_desc', 'format_topcoll', array('url' => $readme)))
-                );
             $courseformatoptions = array_merge_recursive($courseformatoptions, $courseformatoptionsedit);
         }
         return $courseformatoptions;


### PR DESCRIPTION
Hi Gareth, thanks for another very useful plugin! It solves an actual problem as we have several courses that are a bit large :)

We would like to suggest to remove the readme link from course settings. It provides information for administrators, not for teachers. However, it is displayed during course edit instead of in the administrators perspective. As a consequence, teachers tend to be confused when they click the readme link in search for help for their specific problems.