### PR TITLE
Remove override for action menu alignment

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -586,10 +586,6 @@ body.format-topcoll.editing.dir-rtl ul.ctopics .section .activity .activityinsta
     padding-left: 0;
 }
 
-body.format-topcoll.editing ul.ctopics .section .activity .actions {
-    position: relative;
-}
-
 body.format-topcoll.editing #region-main ul.ctopics .moodle-actionmenu ul.menubar {
     display: none;
 }


### PR DESCRIPTION
Hi, another change: The edit action menu looks displaced. At least it is inconsistent with the display in core Moodle formats. This is what it looked like before

![before](https://user-images.githubusercontent.com/432117/54209197-a3518280-44dd-11e9-8743-3faea315b796.png)

and after my change

![after](https://user-images.githubusercontent.com/432117/54209210-a77da000-44dd-11e9-82ed-a7809575835b.png)

The computed styles look like this...

![computed styles](https://user-images.githubusercontent.com/432117/54209230-b2d0cb80-44dd-11e9-8b57-0eb9631e0740.png)

... so I removed the override.

Note: I couldn't find any information as to whether the CSS change was intentional or by accident. So please consider this a mere suggestion; if it was intentional feel free to close this. (Well, obviously. :slightly_smiling_face: Nevertheless, I felt that it was important to mention this.)

