### PR TITLE
Fix error with analytic - get_section_dates function

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -176,9 +176,20 @@ class format_topcoll extends format_base {
         return $o;
     }
 
-    public function get_section_dates($section, $course, $tcsettings) {
+    public function get_section_dates($section, $course = null, $tcsettings = null) {
         $dateformat = get_string('strftimedateshort');
         $o = '';
+
+        if (empty($tcsettings) && empty($course)) {
+            $course = $this->get_course();
+            $dates = $this->format_topcoll_get_section_dates($section, $course);
+            return $dates;
+        }
+
+        if (empty($tcsettings)) {
+            $tcsettings = $this->get_settings();
+        }
+
         if ($tcsettings['layoutstructure'] == 5) {
             $day = $this->format_topcoll_get_section_day($section, $course);
 


### PR DESCRIPTION
Hi Gareth,

Regards #53 
The get_section_dates causes error in task \tool_analytics\task\train_models, which also makes the cron job failed and stop running other task.

I have made $course and $tcsettings optional so the function can be used in analytics

