### PR TITLE
hide mod engagement

### DIFF
--- a/classes/course_renderer.php
+++ b/classes/course_renderer.php
@@ -220,7 +220,9 @@ class format_topcoll_course_renderer extends \core_course_renderer {
         // Get further information.
         $settingname = 'coursesectionactivityfurtherinformation'.$mod->modname;
         $setting = get_config('format_topcoll', $settingname);
-        if (!empty($setting) && ($setting == 2)) {
+        $courseformat = course_get_format($course);
+        $course = $courseformat->get_course();
+        if (!empty($setting) && ($setting == 2) && ($course->showadditionalmoddata == 2)) {
             $cmmetaoutput = $this->course_section_cm_get_meta($mod);
             if (!empty($cmmetaoutput)) {
                 $output .= html_writer::start_tag('div', array('class' => 'ct-activity-meta-container'));

--- a/lang/en/format_topcoll.php
+++ b/lang/en/format_topcoll.php
@@ -116,6 +116,9 @@ $string['layoutstructuretopics'] = 'topics';
 $string['layoutstructureweeks'] = 'weeks';
 $string['layoutstructuredays'] = 'days';
 
+// Coursesetting - Show addtional data for modules
+$string['showadditionalmoddata'] = 'Show additional information for: {$a} in the course';
+$string['showadditionalmoddata_help'] = 'Allow all users to see the deadline and users with grading permission see the number of submission on the course page for activities.';
 
 // Colour enhancement - Moodle Tracker CONTRIB-3529.
 $string['setcolour'] = 'Colour';

--- a/lang/en/format_topcoll.php
+++ b/lang/en/format_topcoll.php
@@ -118,7 +118,7 @@ $string['layoutstructuredays'] = 'days';
 
 // Coursesetting - Show addtional data for modules
 $string['showadditionalmoddata'] = 'Show additional information for: {$a} in the course';
-$string['showadditionalmoddata_help'] = 'Allow all users to see the deadline and users with grading permission see the number of submission on the course page for activities.';
+$string['showadditionalmoddata_help'] = 'Allow all users to see the activity deadline and users with grading permission to see the number of submissions on the course page for activities.';
 
 // Colour enhancement - Moodle Tracker CONTRIB-3529.
 $string['setcolour'] = 'Colour';

--- a/lib.php
+++ b/lib.php
@@ -529,9 +529,9 @@ class format_topcoll extends format_base {
                 )
             );
 
-            /** Case 1 : at least one plugin is set to yes show config with default either:
-            * Previousvalue - in case it was set.
-            * Yes (2) - if no value was set. */
+            /* Case 1 : at least one plugin is set to yes show config with default either:
+               Previousvalue - in case it was set.
+               Yes (2) - if no value was set. */
             if (!empty($enabledplugins)) {
                 $default = get_config('format_topcoll', 'showadditionalmoddata');
                 if ($default == false) {

--- a/lib.php
+++ b/lib.php
@@ -382,7 +382,28 @@ class format_topcoll extends format_base {
     public function course_format_options($foreditform = false) {
         static $courseformatoptions = false;
         $courseconfig = null;
-
+        $enabledplugins = array();
+        $engagaementactivities = array('assign', 'quiz', 'choice', 'feedback', 'lesson', 'data');
+        foreach ($engagaementactivities as $plugintype) {
+            if (get_config('format_topcoll', 'coursesectionactivityfurtherinformation' . $plugintype) == 2) {
+                switch ($plugintype) {
+                    case 'assign':
+                        array_push($enabledplugins, 'assignments');
+                        break;
+                    case 'quiz':
+                        array_push($enabledplugins, 'quizzes');
+                        break;
+                    case 'data':
+                        array_push($enabledplugins, 'databases');
+                        break;
+                    case 'choice' || 'feedback' || 'lesson':
+                        array_push($enabledplugins, $plugintype . 's');
+                        break;
+                    default:
+                        coding_exception('Try to process invalid plugin', 'Check the plugintypes which are supported by format_topcoll');
+                }
+            }
+        }
         if ($courseformatoptions === false) {
             /* Note: Because 'admin_setting_configcolourpicker' in 'settings.php' needs to use a prefixing '#'
                      this needs to be stripped off here if it's there for the format's specific colour picker. */
@@ -507,6 +528,20 @@ class format_topcoll extends format_base {
                     'type' => PARAM_INT,
                 )
             );
+
+            /** Case 1 : at least one plugin is set to yes show config with default either:
+            * Previousvalue - in case it was set.
+            * Yes (2) - if no value was set. */
+            if (!empty($enabledplugins)) {
+                $default = get_config('format_topcoll', 'showadditionalmoddata');
+                if ($default == false) {
+                    $default = 2;
+                }
+                $courseformatoptions['showadditionalmoddata'] = array(
+                    'default' => $default,
+                    'type' => PARAM_INT);
+            }
+
         }
         if ($foreditform && !isset($courseformatoptions['displayinstructions']['label'])) {
             /* Note: Because 'admin_setting_configcolourpicker' in 'settings.php' needs to use a prefixing '#'
@@ -682,6 +717,21 @@ class format_topcoll extends format_base {
                               2 => new lang_string('yes'))
                     )
                 );
+                if (!empty($enabledplugins)) {
+                    $stringenabled = implode(', ', $enabledplugins);
+                    $portion = strrchr($stringenabled, ',');
+                    $stringenabled = str_replace($portion, (" and" . substr($portion, 1)), $stringenabled);
+                    $courseformatoptionsedit['showadditionalmoddata'] = array(
+                        'label' => new lang_string('showadditionalmoddata', 'format_topcoll', $stringenabled),
+                        'help' => 'showadditionalmoddata',
+                        'help_component' => 'format_topcoll',
+                        'element_type' => 'select',
+                        'element_attributes' => array(
+                            array(1 => new lang_string('no'),
+                                2 => new lang_string('yes'))
+                        )
+                    );
+                }
             } else {
                 $courseformatoptionsedit['layoutelement'] = array(
                     'label' => get_config('format_topcoll', 'defaultlayoutelement'), 'element_type' => 'hidden');
@@ -701,6 +751,10 @@ class format_topcoll extends format_base {
                     'label' => get_config('format_topcoll', 'defaultonesection'), 'element_type' => 'hidden');
                 $courseformatoptionsedit['showsectionsummary'] = array(
                     'label' => get_config('format_topcoll', 'defaultshowsectionsummary'), 'element_type' => 'hidden');
+                if (!empty($enabledplugins)) {
+                    $courseformatoptionsedit['showadditionalmoddata'] = array(
+                        'label' => get_config('format_topcoll', 'showadditionalmoddata'), 'element_type' => 'hidden');
+                }
             }
 
             if (has_capability('format/topcoll:changetogglealignment', $context)) {
@@ -1340,6 +1394,7 @@ class format_topcoll extends format_base {
             $updatedata['toggleiconposition'] = get_config('format_topcoll', 'defaulttoggleiconposition');
             $updatedata['onesection'] = get_config('format_topcoll', 'defaultonesection');
             $updatedata['showsectionsummary'] = get_config('format_topcoll', 'defaultshowsectionsummary');
+            $updatedata['showadditionalmoddata'] = get_config('format_topcoll', 'showadditionalmoddata');
             $updatelayout = true;
         }
         if ($togglealignment && has_capability('format/topcoll:changetogglealignment', $context) && $resetallifall) {
@@ -1418,6 +1473,7 @@ class format_topcoll extends format_base {
             $data['toggleallhover'] = get_config('format_topcoll', 'defaulttoggleallhover');
             $data['toggleiconposition'] = get_config('format_topcoll', 'defaulttoggleiconposition');
             $data['toggleiconset'] = get_config('format_topcoll', 'defaulttoggleiconset');
+            $data['showadditionalmoddata'] = get_config('format_topcoll', 'showadditionalmoddata');
         }
         $this->update_course_format_options($data);
 

--- a/lib.php
+++ b/lib.php
@@ -529,19 +529,18 @@ class format_topcoll extends format_base {
                 )
             );
 
-            /* Case 1 : at least one plugin is set to yes show config with default either:
-               Previousvalue - in case it was set.
-               Yes (2) - if no value was set. */
+            /* If at least one plugin is set to yes show config with default either:
+               Previous Value - in case it was set in previous editing of the course
+               Default Value Yes (2) - if no value was set. */
             if (!empty($enabledplugins)) {
-                $default = get_config('format_topcoll', 'showadditionalmoddata');
-                if ($default == false) {
-                    $default = 2;
+                $configshowmod = get_config('format_topcoll', 'showadditionalmoddata');
+                if ($configshowmod == false) {
+                    $configshowmod = 2;
                 }
                 $courseformatoptions['showadditionalmoddata'] = array(
-                    'default' => $default,
+                    'default' => $configshowmod,
                     'type' => PARAM_INT);
             }
-
         }
         if ($foreditform && !isset($courseformatoptions['displayinstructions']['label'])) {
             /* Note: Because 'admin_setting_configcolourpicker' in 'settings.php' needs to use a prefixing '#'

--- a/tests/courseformatlib_test.php
+++ b/tests/courseformatlib_test.php
@@ -125,4 +125,21 @@ class format_topcoll_courseformatlib_testcase extends advanced_testcase {
         $this->assertEquals('0.7', $thesettings['togglebackgroundopacity']);
         $this->assertEquals('0.8', $thesettings['togglebackgroundhoveropacity']);
     }
+
+    public function test_showadditionalmoddata_default_yes() {
+        $this->setAdminUser();
+
+        set_config('coursesectionactivityfurtherinformationchoice', 2, 'format_topcoll');
+        set_config('coursesectionactivityfurtherinformationdata', 2, 'format_topcoll');
+
+        $thesettings = $this->courseformat->get_settings();
+        $this->assertEquals(2, $thesettings['showadditionalmoddata']);
+
+        set_config('coursesectionactivityfurtherinformationchoice', 1, 'format_topcoll');
+        set_config('coursesectionactivityfurtherinformationdata', 1, 'format_topcoll');
+        set_config('coursesectionactivityfurtherinformationlesson', 2, 'format_topcoll');
+
+        $thesettings = $this->courseformat->get_settings();
+        $this->assertEquals(2, $thesettings['showadditionalmoddata']);
+    }
 }

--- a/version.php
+++ b/version.php
@@ -33,7 +33,7 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2020110901;
+$plugin->version = 2020110900;
 $plugin->maturity = MATURITY_BETA;
 $plugin->requires  = 2020110900.00; // 3.10 (Build: 20201109).
 $plugin->component = 'format_topcoll';

--- a/version.php
+++ b/version.php
@@ -33,7 +33,7 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2020110900;
+$plugin->version = 2020110901;
 $plugin->maturity = MATURITY_BETA;
 $plugin->requires  = 2020110900.00; // 3.10 (Build: 20201109).
 $plugin->component = 'format_topcoll';


### PR DESCRIPTION
Hello, 
sorry for the mess and the time wasted!
I put all changed in one commit on this branch with the latest changes of moodle 3.10 version.
For reference those were the goals:
- [x] created course setting for displaying deadline and submissions 
- [x] use the admin settings which are divided for assign lection etc. 
       Remark: I decided to implement that functionality as follows: In case all activities ('assign', 'quiz', 'choice', 'feedback', 'lesson', 'data' ) are deactivated in the admin settings, the course setting is not shown at all. In case at least one of them is activated the setting is shown. The string list all enabled activities so lecturers hopefully do not get confused (lib.php l.705). Another option would be to have an individual setting for each activity also in the course, but I rather considered that as over-engineering as the majority is happy with having it displayed. 
- [x] Fix default is set to 'Yes' when at least one admin configuration is enabled.
- [x] write tests 

This was the feedback/review:

> Can't ~'5d3c540#diff-8f5ff72ef1cf59199cfc4bbf16f2475d09e448601242f0d2c51bb94bd4aa1395R699-R702~  use 'implode' (https://www.php.net/manual/en/function.implode.php) instead?

Thanks, changed to implode :+1: 
https://github.com/NinaHerrmann/moodle-format_topcoll/blob/d8af01bcf20515a97bc7ad2bb917372202807ef3/lib.php#L721
> With 5d3c540#diff-972c351ef4188f1f82cc82207e98147ccbd23e43ddf222a3e5c3f8df5e475d04R120 - better if 'Show additional information for: {$a} in the course';

Thanks, changed that https://github.com/NinaHerrmann/moodle-format_topcoll/blob/d8af01bcf20515a97bc7ad2bb917372202807ef3/lang/en/format_topcoll.php#L120

> As ''Show additional information for {$a} in the course'; - then better English for 5d3c540#diff-8f5ff72ef1cf59199cfc4bbf16f2475d09e448601242f0d2c51bb94bd4aa1395R385-R391 with 5d3c540#diff-8f5ff72ef1cf59199cfc4bbf16f2475d09e448601242f0d2c51bb94bd4aa1395R386 to be 'assignments, quizzes....' etc. And even better if code can be 'assignments, quizzes, lessons and feedbacks' etc. So a trailing 'and' instead of a comma.

Added the `and` :+1: (l.723)
https://github.com/NinaHerrmann/moodle-format_topcoll/blob/d8af01bcf20515a97bc7ad2bb917372202807ef3/lib.php#L723


> https://github.com/gjb2048/moodle-format_topcoll/pull/81/files#diff-8f5ff72ef1cf59199cfc4bbf16f2475d09e448601242f0d2c51bb94bd4aa1395R538 etc. is invalid as you're getting a site setting for the format that does not exist - i.e. /course/format/topcoll/settings.php.

https://github.com/NinaHerrmann/moodle-format_topcoll/blob/d8af01bcf20515a97bc7ad2bb917372202807ef3/lib.php#L532
I am not sure if I got that one correctly. If the setting is not set the function returns false so I fill it with 2, but correct me if I am wrong!


> Multiple line comments (https://github.com/gjb2048/moodle-format_topcoll/pull/81/files#diff-8f5ff72ef1cf59199cfc4bbf16f2475d09e448601242f0d2c51bb94bd4aa1395R532-R535) need to use '/*' etc.

https://github.com/NinaHerrmann/moodle-format_topcoll/blob/d8af01bcf20515a97bc7ad2bb917372202807ef3/lib.php#L532
Used multiline comma, code checker complains I can alternatively make it a oneliner

> Don't add a comma when it is not needed: https://github.com/gjb2048/moodle-format_topcoll/pull/81/files#diff-8f5ff72ef1cf59199cfc4bbf16f2475d09e448601242f0d2c51bb94bd4aa1395R529

implode solves the problem :+1:
https://github.com/NinaHerrmann/moodle-format_topcoll/blob/d8af01bcf20515a97bc7ad2bb917372202807ef3/lib.php#L722

> Here: https://github.com/gjb2048/moodle-format_topcoll/pull/81/files#diff-8f5ff72ef1cf59199cfc4bbf16f2475d09e448601242f0d2c51bb94bd4aa1395R532-R545 have this logic: https://github.com/gjb2048/moodle-format_topcoll/pull/81/files#diff-8f5ff72ef1cf59199cfc4bbf16f2475d09e448601242f0d2c51bb94bd4aa1395R755-R758 sort of thing.

Moved this logic to the top of the function so it can be used multiple times https://github.com/NinaHerrmann/moodle-format_topcoll/blob/d8af01bcf20515a97bc7ad2bb917372202807ef3/lib.php#L387

> So only add
> moodle-format_topcoll/lib.php 
```
 $courseformatoptions['showadditionalmoddata'] = array( 
     'default' => $default, 
     'type' => PARAM_INT); 
```
moodle-format_topcoll/lib.php

Should be added. Not sure if you meant that the if should be removed completely but has now the default value.
https://github.com/NinaHerrmann/moodle-format_topcoll/blob/d8af01bcf20515a97bc7ad2bb917372202807ef3/lib.php#L540

> https://github.com/gjb2048/moodle-format_topcoll/pull/81/files#diff-8f5ff72ef1cf59199cfc4bbf16f2475d09e448601242f0d2c51bb94bd4aa1395R386-R406 needs to be within https://github.com/gjb2048/moodle-format_topcoll/pull/81/files#diff-8f5ff72ef1cf59199cfc4bbf16f2475d09e448601242f0d2c51bb94bd4aa1395R407

I dont think so since it is used in https://github.com/gjb2048/moodle-format_topcoll/blob/688671921c040e8da297fe07d6d39513370b5392/lib.php#L720 but correct me if I am wrong!