### PR TITLE
Blocks optiona

### DIFF
--- a/Changes_blocks_optional.md
+++ b/Changes_blocks_optional.md
@@ -2,7 +2,7 @@ John Joubert -
 GitHub: https://github.com/John-Joubert
 
 The purpose of this branch "blocks_optional" is to allow the blocks display to be optional.
---> This branch "blocks_optional" is a sub-branch of MOODLE_39. 
+--> This branch "blocks_optional" is a sub-branch of MOODLE_310 (current master). 
 
 
 Code changes:

--- a/Changes_blocks_optional.md
+++ b/Changes_blocks_optional.md
@@ -1,0 +1,76 @@
+John Joubert - 
+GitHub: https://github.com/John-Joubert
+
+The purpose of this branch "blocks_optional" is to allow the blocks display to be optional.
+--> This branch "blocks_optional" is a sub-branch of MOODLE_39. 
+
+
+Code changes:
+1) language - Added entries into language files:
+	modified:   lang/en/format_topcoll.php
+	modified:   lang/en_ar/format_topcoll.php
+	modified:   lang/en_us/format_topcoll.php
+
+Last entries in the bottom of the "en" and "en_us" files above: 
+
+// Toggle Display Blocks
+    $string['defaultdisplayblocks'] = 'Display the four blocks that come with this format plugin';
+    $string['defaultdisplayblocks_desc'] = "Display the four blocks that come with this format plugin in the course. Yes or No.";
+
+*Note: additions for en_ar matches style of the rest of the file, or at least tries to
+// Toggle Display Blocks
+    $string['defaultdisplayblocks'] = 'Display the four blocks that come with this format plugin to crew';
+    $string['defaultdisplayblocks_desc'] = "Display the four blocks that come with this format plugin in the course. Can bee Aye or Nay.";
+
+
+2) New settings in settings.php, addition starts at line 50
+
+    /* Toggle instructions - 1 = no, 2 = yes. */
+    $name = 'format_topcoll/defaultdisplayblocks';
+    $title = get_string('defaultdisplayblocks', 'format_topcoll');
+    $description = get_string('defaultdisplayblocks_desc', 'format_topcoll');
+    $default = 2;
+    $choices = array(
+        2 => new lang_string('yes'),// Yes.
+        1 => new lang_string('no')  // No.
+    );  
+    $settings->add(new admin_setting_configselect($name, $title, $description, $default, $choices));
+
+3) Replacement code in lib.php to make the settings of the blocks conditional on the settings for defaultdisplayblocks.
+
+Replacement code is at line 337 of lib.php:
+    /**
+     * Returns the list of blocks to be automatically added for the newly created course
+     *
+     * @return array of default blocks, must contain two keys BLOCK_POS_LEFT and BLOCK_POS_RIGHT
+     *     each of values is an array of block names (for left and right side columns)
+     */
+    public function get_default_blocks() {
+        $use_def_blocks = get_config('format_topcoll', 'defaultdisplayblocks');
+        if ($use_def_blocks == 1) /* 1 = No, 2 = Yes (default)*/ {
+            return array(
+                BLOCK_POS_LEFT => array(),
+                BLOCK_POS_RIGHT => array()
+            );
+        }
+        else { /* if $use_def_blocks is not 1, then we turn on the four blocks, since it is intended as the default */
+            return array(
+                BLOCK_POS_LEFT => array(),
+                BLOCK_POS_RIGHT => array('search_forums', 'news_items', 'calendar_upcoming', 'recent_activity')
+            );
+        }
+    }
+
+Original Code at line 337 of lib.php:
+    /**
+     * Returns the list of blocks to be automatically added for the newly created course
+     *
+     * @return array of default blocks, must contain two keys BLOCK_POS_LEFT and BLOCK_POS_RIGHT
+     *     each of values is an array of block names (for left and right side columns)
+     */
+    public function get_default_blocks() {
+        return array(
+            BLOCK_POS_LEFT => array(),
+            BLOCK_POS_RIGHT => array('search_forums', 'news_items', 'calendar_upcoming', 'recent_activity')
+        );
+    }

--- a/lang/en/format_topcoll.php
+++ b/lang/en/format_topcoll.php
@@ -434,3 +434,8 @@ $string['privacy:request:preference:toggle'] = 'The course id "{$a->name}" has t
 // Readme.
 $string['readme_title'] = 'Collapsed Topics read-me';
 $string['readme_desc'] = 'Please click on \'{$a->url}\' for lots more information about Collapsed Topics.';
+
+// Toggle Display Blocks
+$string['defaultdisplayblocks'] = 'Display the four blocks that come with this format plugin';
+$string['defaultdisplayblocks_desc'] = "Display the four blocks that come with this format plugin in the course. Yes or No.";
+

--- a/lang/en/format_topcoll.php
+++ b/lang/en/format_topcoll.php
@@ -438,4 +438,3 @@ $string['readme_desc'] = 'Please click on \'{$a->url}\' for lots more informatio
 // Toggle Display Blocks
 $string['defaultdisplayblocks'] = 'Display the four blocks that come with this format plugin';
 $string['defaultdisplayblocks_desc'] = "Display the four blocks that come with this format plugin in the course. Yes or No.";
-

--- a/lang/en_ar/format_topcoll.php
+++ b/lang/en_ar/format_topcoll.php
@@ -224,3 +224,7 @@ $string['defaulttoggleborderradiusbr'] = 'Toggle bottom right border radius';
 $string['defaulttoggleborderradiusbr_desc'] = 'Border bottom right radius of thy toggle.';
 $string['defaulttoggleborderradiusbl'] = 'Toggle bottom left border radius';
 $string['defaulttoggleborderradiusbl_desc'] = 'Border bottom left radius of thy toggle.';
+
+// Toggle Display Blocks
+$string['defaultdisplayblocks'] = 'Display the four blocks that come with this format plugin to crew';
+$string['defaultdisplayblocks_desc'] = "Display the four blocks that come with this format plugin in the course. Can bee Aye or Nay.";

--- a/lang/en_us/format_topcoll.php
+++ b/lang/en_us/format_topcoll.php
@@ -67,3 +67,6 @@ $string['defaulttgbghvrcolour_desc'] = "Toggle background hover color in hexidec
 // Capabilities.
 $string['topcoll:changecolour'] = 'Change or reset the color';
 
+// Toggle Display Blocks
+$string['defaultdisplayblocks'] = 'Display the four blocks that come with this format plugin';
+$string['defaultdisplayblocks_desc'] = "Display the four blocks that come with this format plugin in the course. Yes or No.";

--- a/lib.php
+++ b/lib.php
@@ -341,10 +341,19 @@ class format_topcoll extends format_base {
      *     each of values is an array of block names (for left and right side columns)
      */
     public function get_default_blocks() {
-        return array(
-            BLOCK_POS_LEFT => array(),
-            BLOCK_POS_RIGHT => array('search_forums', 'news_items', 'calendar_upcoming', 'recent_activity')
-        );
+        $use_def_blocks = get_config('format_topcoll', 'defaultdisplayblocks');
+	if ($use_def_blocks == 1) /* 1 = No, 2 = Yes (default)*/ {
+            return array( 
+	        BLOCK_POS_LEFT => array(), 
+                BLOCK_POS_RIGHT => array() 
+	    );
+	}
+	else { /* if $use_def_blocks is not 1, then we turn on the four blocks, since it is intended as the default */
+            return array( 
+                BLOCK_POS_LEFT => array(),
+		BLOCK_POS_RIGHT => array('search_forums', 'news_items', 'calendar_upcoming', 'recent_activity') 
+	    );
+        }
     }
 
     public function section_format_options($foreditform = false) {

--- a/settings.php
+++ b/settings.php
@@ -48,6 +48,17 @@ if ($ADMIN->fulltree) {
     );
     $settings->add(new admin_setting_configselect($name, $title, $description, $default, $choices));
 
+    /* Toggle display blocks - 1 = no, 2 = yes. */
+    $name = 'format_topcoll/defaultdisplayblocks';
+    $title = get_string('defaultdisplayblocks', 'format_topcoll');
+    $description = get_string('defaultdisplayblocks_desc', 'format_topcoll');
+    $default = 2;
+    $choices = array(
+        2 => new lang_string('yes'),// Yes.
+        1 => new lang_string('no')  // No.
+    );
+    
+    $settings->add(new admin_setting_configselect($name, $title, $description, $default, $choices));
     /* Layout configuration.
       Here you can see what numbers in the array represent what layout for setting the default value below.
       1 => Toggle word, toggle section x and section number - default.


### PR DESCRIPTION
Gareth.

--  Note: New text - I fixed the Change_blocks_optional.md file to read Moodle 3.10 not Moodle 3.9 
So this version is ready to go.

-- Notes below are from before - leaving here to just leave a trail.

Here is the same update as before for the 3.10 version.
The code is the same. I compared the lib.php and settings.php between the plugins 3.9 version and plugins 3.10 version, And I saw they were the same, so I simply added my code in the two files in the same exact place as the 3.9 version.
For the language files - I took the 3.10 versions and added my two string definitions to the bottom of the 3.10 language files.

I noticed that the comment for line 51 on the settings.php is wrong.  I've corrected this in the Moodle 3.10 version. 
I also mistakenly used the same "Change_blocks_optional.md" file for this version.   The only thing in it that has to change is that I mention Moodle 3.9 instead off Moodle 3.10.

I'll fix the above two things (the Change_blocks_optional.md file in this version, and the settings.php version in the Moodle 3.9 version).
Sorry about that - I was REALLY wanting to leave very clean direct trail for you.  
In this case - each one will just a single update - you'll see them on the commits. 

Thanks,

John Joubert