### PR TITLE
Extend core_courseformat\base instead of format_base.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -34,7 +34,7 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/course/format/lib.php'); // For format_base.
 
-class format_topcoll extends format_base {
+class format_topcoll extends core_courseformat\base {
     // Used to determine the type of view URL to generate - parameter or anchor.
     private $coursedisplay = COURSE_DISPLAY_SINGLEPAGE;
     private $settings;


### PR DESCRIPTION
To circumvent a warning at some time in the future you would to have to extend core_courseformat\base instead of format_base.