### PR TITLE
Add ajax support

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -117,6 +117,18 @@ class format_topcoll extends core_courseformat\base {
         return true;
     }
 
+
+    /**
+     * Returns the information about the ajax support. Topcoll uses ajax.
+     *
+     * @return stdClass
+     */
+    public function supports_ajax() {
+        $ajaxsupport = new stdClass();
+        $ajaxsupport->capable = true;
+        return $ajaxsupport;
+    }
+
     /**
      * This format is compatible with the React updates.
      */


### PR DESCRIPTION
Closes #121 

The issue about #121 was:

The module `/course/amd/src/actions.js` was not loaded, because format was not declaring that it is using ajax. This `actions` module therefore never has been properly loaded, because we leave ajax support initialisation at https://github.com/moodle/moodle/blob/e161f1d7746eb3c3f9812c0e3421988e65252e72/course/lib.php#L3049 and never reach https://github.com/moodle/moodle/blob/e161f1d7746eb3c3f9812c0e3421988e65252e72/course/lib.php#L3135

Because of that the jquery event listeners are not being registered and there is no reaction to the events of the inplaceeditable items, probably also changing of course module names and different other things are broken at the moment because of that.