### PR TITLE
MBS-6531: Disable indentation for moodle 4.0

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -104,8 +104,15 @@ class format_topcoll extends core_courseformat\base {
         return true;
     }
 
+    /**
+     * Indentation is deprecated in moodle 4.0.
+     * Function will return false when using moodle 4.0.
+     * 
+     * @return bool 
+     */
     public function uses_indentation(): bool {
-        return true;
+        global $CFG;
+        return $CFG->version < 2022041900;
     }
 
     /**


### PR DESCRIPTION
Moodle 4.0 does not support indentation anymore. The controls for indenting/outdenting are appearing but have no effect. This PR disables indentation on systems running moodle 4.0.