### PR TITLE
Prevent qbank activities from being displayed after an activity move

### DIFF
--- a/classes/external/get_state.php
+++ b/classes/external/get_state.php
@@ -119,7 +119,7 @@ class get_state extends get_state_base {
         foreach ($modinfo->cms as $cm) {
             if (!empty($sections[$cm->sectionnum])) {
                 $section = $sections[$cm->sectionnum];
-                if ($cm->is_visible_on_course_page()) {
+                if ($cm->is_visible_on_course_page() && $cm->is_of_type_that_can_display()) {
                     // Only return this course module data if it's visible by current user on the course page.
                     $cmstate = new $cmclass($courseformat, $section, $cm, istrackeduser: $istrackeduser);
                     $result->cm[] = $cmstate->export_for_template($renderer);

--- a/classes/output/courseformat/state/section.php
+++ b/classes/output/courseformat/state/section.php
@@ -91,7 +91,7 @@ class section extends section_base {
 
         foreach ($modinfo->sections[$section->section] as $modnumber) {
             $mod = $modinfo->cms[$modnumber];
-            if ($section->uservisible && $mod->is_visible_on_course_page()) {
+            if ($section->uservisible && $mod->is_visible_on_course_page() && $mod->is_of_type_that_can_display()) {
                 $data->cmlist[] = $mod->id;
             }
         }


### PR DESCRIPTION
In Moodle 5.0, there is a bug when moving an activity in a course that contains a question bank.

After moving, the new "qbank" module appears as activity in the course interface, when it shouldn't be.

We propose this fix, based on the changes made in the Moodle core ([here](https://github.com/moodle/moodle/commit/776d1e40e41#diff-411b90dd9540447a494d1b078ee7efef5d6199426748616e98588a4f7b0a04fe) and [there](https://github.com/moodle/moodle/commit/776d1e40e41#diff-58a4a6e00569c2595dc6eaa9d39dcbd8c804e73d7d369b01d40030f986f66809)).

I'm not sure, but maybe `is_of_type_that_can_display()` should be used [in this case](https://github.com/gjbarnard/moodle-format_topcoll/blob/60ff39ed2b085957a18b94407fa7524174ba05c3/classes/activity.php#L992) too ?