### PR TITLE
Adds label to section selector dropdown.

### DIFF
--- a/classes/output/courseformat/content/sectionselector.php
+++ b/classes/output/courseformat/content/sectionselector.php
@@ -82,7 +82,7 @@ class sectionselector extends \core_courseformat\output\local\content\sectionsel
         $select = new url_select($sectionmenu, '', ['' => get_string('jumpto')]);
         $select->class = 'jumpmenu';
         $select->formid = 'sectionmenu';
-
+        $select->set_label(get_string('jumptosection', 'format_topcoll'), ['class' => 'accesshide']);
         $data->selector = $output->render($select);
 
         return $data;

--- a/lang/en/format_topcoll.php
+++ b/lang/en/format_topcoll.php
@@ -65,6 +65,7 @@ $string['showfromothers'] = 'Show';
 $string['currentsection'] = 'This section';
 $string['editsection'] = 'Edit section';
 $string['deletesection'] = 'Delete section';
+$string['jumptosection'] = 'Jump to section';
 // These are 'sections' as they are only shown in 'section' based structures.
 $string['markedthissection'] = 'This section is highlighted as the current section';
 $string['markthissection'] = 'Highlight this section as the current section';


### PR DESCRIPTION
This add a label - visible to screen-readers only - to the section selector dropdown.

<img width="1327" height="888" alt="image" src="https://github.com/user-attachments/assets/9ba1eb53-a897-49fc-b7c9-1c88757a4ee2" />

refs #183 