### PR TITLE
Adjustments for Moodle 5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.3']
-        moodle-branch: ['MOODLE_500_STABLE']
+        moodle-branch: ['MOODLE_501_STABLE']
         database: [mariadb]
 
     steps:

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -580,7 +580,7 @@ class renderer extends section_renderer {
         if ($section->uservisible) {
             $sectioncontext['cscml'] = $this->course_section_cmlist($section);
             if ($this->courseformat->show_editor()) {
-                $sectioncontext['cscml'] .= $this->course_section_add_cm_control($course, $section->section, $sectionreturn);
+                $sectioncontext['cscml'] .= $this->section_add_cm_controls($this->courseformat, $section);
             }
         }
 
@@ -712,7 +712,7 @@ class renderer extends section_renderer {
 
         if ($this->courseformat->show_editor()) {
             $stealthsectioncontext['cmcontrols'] =
-                $this->course_section_add_cm_control($course, $section->section, $section->section);
+                $this->section_add_cm_controls($this->courseformat, $section);
         }
 
         return $this->render_from_template('format_topcoll/stealthsection', $stealthsectioncontext);

--- a/templates/local/content/addsection.mustache
+++ b/templates/local/content/addsection.mustache
@@ -62,7 +62,7 @@
             {{#pix}}t/block, moodle{{/pix}}
         </div>
         <div class="w-100 font-italic text-center">
-            {{#str}}maxsectionaddmessage, core_courseformat{{/str}}
+            {{#str}}sectionaddmax, core_courseformat{{/str}}
         </div>
     </div>
     {{#decrease}}

--- a/templates/local/content/cm.mustache
+++ b/templates/local/content/cm.mustache
@@ -23,7 +23,7 @@
 {{#editing}}
     {{< core_courseformat/local/content/divider}}
         {{$content}}
-            {{#activitychooserbutton}}{{> core_course/activitychooserbutton}}{{/activitychooserbutton}}
+            {{#activitychooserbutton}}{{> core_courseformat/local/content/activitychooserbutton}}{{/activitychooserbutton}}
         {{/content}}
     {{/ core_courseformat/local/content/divider}}
 {{/editing}}


### PR DESCRIPTION
During the update we went into problems in courses using the topcol format.

The fix in the template was taken from #188 which is already closed. However, I did not find the mentioned branch where the improvements where done.

Anyway, there were a few minor glitches that only lead to deprecation warnings but the existing code is still working with 5.1. The changes proposed here are to get rid of the warnings. Also that code will apparently not work with Moodle versions below 5.1.